### PR TITLE
Fix WildFly streaming by replacing JAX-RS SSE with custom implementation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,3 +43,13 @@ jobs:
       - name: Run tests
         run:
           mvn clean install -B -Dversion.sdk=${SDK_VERSION}
+      - name: Upload WildFly logs on test failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wildfly-logs
+          path: |
+            tests/jsonrpc/target/wildfly/standalone/log/server.log
+            tests/grpc/target/wildfly/standalone/log/server.log
+          if-no-files-found: ignore
+          retention-days: 5

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,17 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+      - name: Check if SDK version is SNAPSHOT
+        run: |
+          SDK_VERSION=$(mvn help:evaluate -Dexpression=version.sdk -q -DforceStdout)
+          echo "SDK_VERSION=${SDK_VERSION}" >> "$GITHUB_ENV"
+          if [[ "${SDK_VERSION}" == *"-SNAPSHOT" ]]; then
+            echo "IS_SNAPSHOT=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_SNAPSHOT=false" >> "$GITHUB_ENV"
+          fi
       - name: Checkout a2a-java
+        if: env.IS_SNAPSHOT == 'true'
         uses: actions/checkout@v4
         with:
           repository: a2aproject/a2a-java
@@ -33,9 +43,12 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Build a2a-java with Maven, skipping tests
-        run: mvn -B install -DskipTests
+        if: env.IS_SNAPSHOT == 'true'
+        run: |
+          mvn -B install -DskipTests
         working-directory: a2a-java
       - name: Get a2a-java version and save as env var
+        if: env.IS_SNAPSHOT == 'true'
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) 
           echo "SDK_VERSION=${VERSION}" >> "$GITHUB_ENV"

--- a/impl/jsonrpc/src/main/java/org/wildfly/extras/a2a/server/apps/jakarta/A2AServerResource.java
+++ b/impl/jsonrpc/src/main/java/org/wildfly/extras/a2a/server/apps/jakarta/A2AServerResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
@@ -128,12 +129,10 @@ import org.slf4j.LoggerFactory;
         LOGGER.debug("Handling streaming request with custom SSE response");
         
         // Set SSE headers manually for proper streaming
-        response.setContentType("text/event-stream");
+        response.setContentType(MediaType.SERVER_SENT_EVENTS);
         response.setCharacterEncoding("UTF-8");
-        response.setHeader("Cache-Control", "no-cache");
-        response.setHeader("Connection", "keep-alive");
-        response.setHeader("Access-Control-Allow-Origin", "*");
-        
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+
         // Get the ObjectMapper from JAX-RS context
         ObjectMapper objectMapper = providers.getContextResolver(ObjectMapper.class, MediaType.APPLICATION_JSON_TYPE)
                 .getContext(JSONRPCResponse.class);


### PR DESCRIPTION
JAX-RS SseEventSink introduced in PR a2aproject/a2a-java#247 was incompatible with async Flow.Publisher lifecycle, causing premature connection closure and serialization failures.

Solution:
- Replace SseEventSink with direct HttpServletResponse SSE handling
- Configure ObjectMapper with JSR310 module for OffsetDateTime support
- Implement proper Flow.Publisher subscription with completion tracking

This restores WildFly streaming parity with Quarkus implementation.