### PR TITLE
fix: harden http-common module with RFC-compliant JSON escaping and u…

### DIFF
--- a/compat-0.3/jsonrpc/src/main/java/org/wildfly/a2a/jakarta/jsonrpc/compat03/A2AServerResource_v0_3.java
+++ b/compat-0.3/jsonrpc/src/main/java/org/wildfly/a2a/jakarta/jsonrpc/compat03/A2AServerResource_v0_3.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.SecurityContext;
 
 import org.a2aproject.sdk.compat03.transport.jsonrpc.handler.JSONRPCHandler_v0_3;
 
+// JAX-RS @Path annotations cannot be parameterized, so each protocol version requires a separate resource class.
 @Path("/a2a_jsonrpc_v0.3")
 public class A2AServerResource_v0_3 {
 
@@ -25,6 +26,7 @@ public class A2AServerResource_v0_3 {
 
     private A2AServerResourceDelegate_v0_3 delegate;
 
+    // Per-request JAX-RS resource — no synchronization needed; each request gets a new instance.
     private A2AServerResourceDelegate_v0_3 getDelegate() {
         if (delegate == null) {
             delegate = new A2AServerResourceDelegate_v0_3(jsonRpcHandler);

--- a/compat-0.3/rest/src/main/java/org/wildfly/a2a/jakarta/rest/compat03/A2ARestServerResource_v0_3.java
+++ b/compat-0.3/rest/src/main/java/org/wildfly/a2a/jakarta/rest/compat03/A2ARestServerResource_v0_3.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.core.SecurityContext;
 import org.a2aproject.sdk.compat03.transport.rest.handler.RestHandler_v0_3;
 import org.wildfly.a2a.jakarta.rest.compat03.A2ARestServerResourceDelegate_v0_3;
 
+// JAX-RS @Path annotations cannot be parameterized, so each protocol version requires a separate resource class.
 @Path("/a2a_rest_v0.3/v1")
 public class A2ARestServerResource_v0_3 {
 
@@ -29,6 +30,7 @@ public class A2ARestServerResource_v0_3 {
 
     private A2ARestServerResourceDelegate_v0_3 delegate;
 
+    // Per-request JAX-RS resource — no synchronization needed; each request gets a new instance.
     private A2ARestServerResourceDelegate_v0_3 getDelegate() {
         if (delegate == null) {
             delegate = new A2ARestServerResourceDelegate_v0_3(restHandler);

--- a/http-common/pom.xml
+++ b/http-common/pom.xml
@@ -52,5 +52,15 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AJsonRpcAcceptFilter.java
+++ b/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AJsonRpcAcceptFilter.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -32,7 +33,6 @@ import org.slf4j.LoggerFactory;
 public class A2AJsonRpcAcceptFilter implements ContainerRequestFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(A2AJsonRpcAcceptFilter.class);
-    private static final String JSONRPC_PREFIX = "/a2a_jsonrpc_";
     private static final Pattern ID_PATTERN = Pattern.compile("\"id\"\\s*:\\s*(\\d+|\"[^\"]*\"|null)");
 
     @Inject
@@ -58,7 +58,7 @@ public class A2AJsonRpcAcceptFilter implements ContainerRequestFilter {
                     }
                     List<A2AVersionProvider> jsonRpcProviders = new ArrayList<>();
                     for (A2AVersionProvider provider : allVersionProviders) {
-                        if (provider.getInternalPathPrefix().startsWith(JSONRPC_PREFIX)) {
+                        if (provider.getInternalPathPrefix().startsWith(InternalPaths.JSONRPC_PREFIX)) {
                             jsonRpcProviders.add(provider);
                         }
                     }
@@ -84,7 +84,7 @@ public class A2AJsonRpcAcceptFilter implements ContainerRequestFilter {
         String requestBody;
         try (InputStream entityInputStream = requestContext.getEntityStream()) {
             byte[] requestBodyBytes = entityInputStream.readAllBytes();
-            requestBody = new String(requestBodyBytes);
+            requestBody = new String(requestBodyBytes, StandardCharsets.UTF_8);
 
             if (isStreamingRequest(requestBody)) {
                 LOGGER.debug("Handling request as streaming: {}", requestBody);
@@ -96,7 +96,7 @@ public class A2AJsonRpcAcceptFilter implements ContainerRequestFilter {
 
             requestContext.setEntityStream(new ByteArrayInputStream(requestBodyBytes));
         } catch (IOException e) {
-            throw new RuntimeException("Unable to read the request body");
+            throw new RuntimeException("Unable to read the request body", e);
         }
 
         String versionHeader = requestContext.getHeaderString(A2AHeaders.A2A_VERSION);
@@ -106,7 +106,7 @@ public class A2AJsonRpcAcceptFilter implements ContainerRequestFilter {
             requestContext.abortWith(
                     Response.status(Response.Status.BAD_REQUEST)
                             .entity("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32009,\"message\":\"Protocol version '"
-                                    + versionHeader + "' is not supported. Supported versions: "
+                                    + InternalPaths.escapeJsonValue(versionHeader) + "' is not supported. Supported versions: "
                                     + versionResolver.supportedVersionsString() + "\"},\"id\":" + requestId + "}")
                             .type(MediaType.APPLICATION_JSON)
                             .build());

--- a/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2ARestVersionRoutingFilter.java
+++ b/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2ARestVersionRoutingFilter.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 public class A2ARestVersionRoutingFilter implements ContainerRequestFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(A2ARestVersionRoutingFilter.class);
-    private static final String A2A_INTERNAL_PREFIX = "/a2a_";
 
     @Inject
     Instance<A2AVersionProvider> allVersionProviders;
@@ -64,7 +63,7 @@ public class A2ARestVersionRoutingFilter implements ContainerRequestFilter {
         if (path.startsWith("/.well-known/")) {
             return;
         }
-        if (path.startsWith(A2A_INTERNAL_PREFIX)) {
+        if (path.startsWith(InternalPaths.A2A_PREFIX)) {
             return;
         }
 
@@ -94,7 +93,7 @@ public class A2ARestVersionRoutingFilter implements ContainerRequestFilter {
             requestContext.abortWith(
                     Response.status(Response.Status.BAD_REQUEST)
                             .entity("{\"error\":{\"code\":-32001,\"message\":\"Protocol version '"
-                                    + versionHeader + "' is not supported. Supported versions: "
+                                    + InternalPaths.escapeJsonValue(versionHeader) + "' is not supported. Supported versions: "
                                     + versionResolver.supportedVersionsString() + "\"}}")
                             .type(MediaType.APPLICATION_JSON)
                             .build());

--- a/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AVersionProvider.java
+++ b/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AVersionProvider.java
@@ -4,14 +4,20 @@ public interface A2AVersionProvider {
 
     String getVersion();
 
+    /**
+     * Returns {@code true} if this is the default version for its transport.
+     * <p>
+     * Each {@link A2AVersionResolver} is scoped to a single transport (JSON-RPC or REST),
+     * so a JSON-RPC provider and a REST provider may both return {@code true} without
+     * conflicting — they are registered in separate resolvers.
+     */
     boolean isDefaultVersion();
 
     String getInternalPathPrefix();
 
     /**
-     * The client-facing REST base path for this version.
-     * "/" for v1.0, "/v1" for v0.3.
-     * Return null for JSON-RPC-only providers.
+     * The client-facing REST base path for this version (e.g. {@code "/"} or {@code "/v1"}).
+     * Return {@code null} for JSON-RPC-only providers.
      */
     String getRestBasePath();
 }

--- a/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AVersionResolver.java
+++ b/http-common/src/main/java/org/wildfly/a2a/jakarta/common/A2AVersionResolver.java
@@ -1,17 +1,20 @@
 package org.wildfly.a2a.jakarta.common;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class A2AVersionResolver {
 
-    private final Map<String, A2AVersionProvider> providersByVersion = new HashMap<>();
+    private final Map<String, A2AVersionProvider> providersByVersion = new LinkedHashMap<>();
     private A2AVersionProvider defaultProvider;
 
     public A2AVersionResolver(Iterable<A2AVersionProvider> providers) {
         for (A2AVersionProvider provider : providers) {
             providersByVersion.put(provider.getVersion(), provider);
             if (provider.isDefaultVersion()) {
+                if (defaultProvider != null) {
+                    throw new IllegalStateException("Only one default version provider should be defined. We have at least 2: %s and %s".formatted(defaultProvider, provider));
+                }
                 defaultProvider = provider;
             }
         }
@@ -36,6 +39,6 @@ public class A2AVersionResolver {
     }
 
     public String supportedVersionsString() {
-        return providersByVersion.keySet().toString();
+        return String.join(", ", providersByVersion.keySet());
     }
 }

--- a/http-common/src/main/java/org/wildfly/a2a/jakarta/common/InternalPaths.java
+++ b/http-common/src/main/java/org/wildfly/a2a/jakarta/common/InternalPaths.java
@@ -1,0 +1,35 @@
+package org.wildfly.a2a.jakarta.common;
+
+class InternalPaths {
+
+    static final String A2A_PREFIX = "/a2a_";
+    static final String JSONRPC_PREFIX = A2A_PREFIX + "jsonrpc_";
+
+    static String escapeJsonValue(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"'  -> sb.append("\\\"");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default   -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private InternalPaths() {
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2AJsonRpcAcceptFilterTest.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2AJsonRpcAcceptFilterTest.java
@@ -1,0 +1,209 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.a2aproject.sdk.common.A2AHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, RuntimeDelegateExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
+class A2AJsonRpcAcceptFilterTest {
+
+    private static final String STREAMING_METHOD = "tasks/sendSubscribe";
+    private static final String NON_STREAMING_METHOD = "tasks/send";
+
+    @Mock
+    Instance<A2AVersionProvider> allVersionProviders;
+
+    @Mock
+    Instance<A2AJsonRpcMethodProvider> methodProviders;
+
+    @InjectMocks
+    A2AJsonRpcAcceptFilter filter;
+
+    private void setupProvider(A2AVersionProvider... providers) {
+        when(allVersionProviders.iterator()).thenAnswer(inv -> List.of(providers).iterator());
+        A2AJsonRpcMethodProvider methodProvider = new A2AJsonRpcMethodProvider() {
+            @Override public Set<String> getStreamingMethodNames() { return Set.of(STREAMING_METHOD); }
+            @Override public Set<String> getNonStreamingMethodNames() { return Set.of(NON_STREAMING_METHOD); }
+        };
+        when(methodProviders.iterator()).thenAnswer(inv -> List.of(methodProvider).iterator());
+    }
+
+    private static ContainerRequestContext mockJsonRpcContext(String body) {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/");
+        when(ctx.getMethod()).thenReturn("POST");
+        when(ctx.hasEntity()).thenReturn(true);
+        when(ctx.getEntityStream()).thenReturn(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        when(ctx.getHeaders()).thenReturn(new MultivaluedHashMap<>());
+        return ctx;
+    }
+
+    @Test
+    void nonPostRequest_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/");
+        when(ctx.getMethod()).thenReturn("GET");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).getEntityStream();
+    }
+
+    @Test
+    void nonRootPath_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/api/something");
+        when(ctx.getMethod()).thenReturn("POST");
+        when(ctx.hasEntity()).thenReturn(true);
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).getEntityStream();
+    }
+
+    @Test
+    void noEntity_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/");
+        when(ctx.getMethod()).thenReturn("POST");
+        when(ctx.hasEntity()).thenReturn(false);
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).getEntityStream();
+    }
+
+    @Test
+    void streamingMethod_setsSSEAcceptHeader() throws IOException {
+        // Use an unknown version to abort before URI building, allowing us to verify the Accept header was set.
+        setupProvider(TestProviders.jsonRpcProvider("1.0", true));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + STREAMING_METHOD + "\",\"id\":1}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+        when(ctx.getHeaders()).thenReturn(headers);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        assertEquals(MediaType.SERVER_SENT_EVENTS, headers.getFirst("Accept"));
+        verify(ctx).abortWith(any());
+    }
+
+    @Test
+    void nonStreamingMethod_setsJsonAcceptHeader() throws IOException {
+        setupProvider(TestProviders.jsonRpcProvider("1.0", true));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + NON_STREAMING_METHOD + "\",\"id\":1}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+        when(ctx.getHeaders()).thenReturn(headers);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        assertEquals(MediaType.APPLICATION_JSON, headers.getFirst("Accept"));
+        verify(ctx).abortWith(any());
+    }
+
+    @Test
+    void unknownVersionHeader_abortsWithJsonRpcError() throws IOException {
+        setupProvider(TestProviders.jsonRpcProvider("1.0", true));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + NON_STREAMING_METHOD + "\",\"id\":42}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(responseCaptor.capture());
+        assertEquals(400, responseCaptor.getValue().getStatus());
+        String responseBody = responseCaptor.getValue().getEntity().toString();
+        assertTrue(responseBody.contains("\"id\":42"), "JSON-RPC error must include the request id");
+    }
+
+    @Test
+    void errorResponse_containsEscapedVersionHeader() throws IOException {
+        setupProvider(TestProviders.jsonRpcProvider("1.0", true));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + NON_STREAMING_METHOD + "\",\"id\":1}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("bad\"version");
+
+        filter.filter(ctx);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(responseCaptor.capture());
+        String responseBody = responseCaptor.getValue().getEntity().toString();
+        assertFalse(responseBody.contains("\"version\""), "Unescaped quote must not appear in JSON body");
+        assertTrue(responseBody.contains("\\\""), "Quote must be JSON-escaped in error body");
+    }
+
+    @Test
+    void multipleProviders_noDefault_unknownVersion_abortsWithError() throws IOException {
+        setupProvider(
+                TestProviders.jsonRpcProvider("1.0", false),
+                TestProviders.jsonRpcProvider("0.3", false));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + NON_STREAMING_METHOD + "\",\"id\":1}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        verify(ctx).abortWith(any(Response.class));
+    }
+
+    @Test
+    void multipleProviders_noDefault_nullVersionHeader_abortsWithError() throws IOException {
+        setupProvider(
+                TestProviders.jsonRpcProvider("1.0", false),
+                TestProviders.jsonRpcProvider("0.3", false));
+
+        String body = "{\"jsonrpc\":\"2.0\",\"method\":\"" + NON_STREAMING_METHOD + "\",\"id\":1}";
+        ContainerRequestContext ctx = mockJsonRpcContext(body);
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn(null);
+
+        filter.filter(ctx);
+
+        verify(ctx).abortWith(any(Response.class));
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2ARestVersionRoutingFilterTest.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2ARestVersionRoutingFilterTest.java
@@ -1,0 +1,155 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.a2aproject.sdk.common.A2AHeaders;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, RuntimeDelegateExtension.class})
+@MockitoSettings(strictness = Strictness.LENIENT)
+class A2ARestVersionRoutingFilterTest {
+
+    @Mock
+    Instance<A2AVersionProvider> allVersionProviders;
+
+    @InjectMocks
+    A2ARestVersionRoutingFilter filter;
+
+    private void setupProvider(A2AVersionProvider... providers) {
+        when(allVersionProviders.iterator()).thenAnswer(inv -> List.of(providers).iterator());
+    }
+
+    @Test
+    void wellKnownPath_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/.well-known/agent-card.json");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(), any());
+        verify(ctx, never()).abortWith(any());
+    }
+
+    @Test
+    void internalA2aPath_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/a2a_rest_v1.0/tasks");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(), any());
+        verify(ctx, never()).abortWith(any());
+    }
+
+    @Test
+    void noVersionHeader_onlyRootBasePath_isSkipped() throws IOException {
+        setupProvider(TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks/123");
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn(null);
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+
+    @Test
+    void multipleProviders_noDefault_nullVersionHeader_isSkipped() throws IOException {
+        setupProvider(
+                TestProviders.provider("1.0", false, "/a2a_rest_v1.0", "/"),
+                TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/unknown-path");
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn(null);
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).abortWith(any());
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+
+    @Test
+    void unknownVersionHeader_abortsWithBadRequest() throws IOException {
+        setupProvider(TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks/123");
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(responseCaptor.capture());
+        assertEquals(400, responseCaptor.getValue().getStatus());
+    }
+
+    @Test
+    void errorResponse_containsEscapedVersionHeader() throws IOException {
+        setupProvider(TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks/123");
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("bad\"version");
+
+        filter.filter(ctx);
+
+        ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+        verify(ctx).abortWith(responseCaptor.capture());
+        String body = responseCaptor.getValue().getEntity().toString();
+        assertFalse(body.contains("\"version\""), "Unescaped quote must not appear in JSON body");
+        assertTrue(body.contains("\\\""), "Quote must be JSON-escaped in error body");
+    }
+
+    @Test
+    void multipleProviders_noDefault_unknownVersion_abortsWithBadRequest() throws IOException {
+        setupProvider(
+                TestProviders.provider("1.0", false, "/a2a_rest_v1.0", "/"),
+                TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks/123");
+        when(ctx.getHeaderString(A2AHeaders.A2A_VERSION)).thenReturn("99.0");
+
+        filter.filter(ctx);
+
+        verify(ctx).abortWith(any(Response.class));
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2AVersionResolverTest.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/A2AVersionResolverTest.java
@@ -1,0 +1,97 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class A2AVersionResolverTest {
+
+    @Test
+    void resolveByHeader_returnsMatchingProvider() {
+        A2AVersionProvider p1 = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionProvider p2 = TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p1, p2));
+
+        assertSame(p1, resolver.resolve("1.0"));
+        assertSame(p2, resolver.resolve("0.3"));
+    }
+
+    @Test
+    void resolveNullHeader_returnsDefaultProvider() {
+        A2AVersionProvider defaultProvider = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionProvider other = TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(defaultProvider, other));
+
+        assertSame(defaultProvider, resolver.resolve(null));
+    }
+
+    @Test
+    void resolveBlankHeader_returnsDefaultProvider() {
+        A2AVersionProvider defaultProvider = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(defaultProvider));
+
+        assertSame(defaultProvider, resolver.resolve("  "));
+    }
+
+    @Test
+    void resolveUnknownHeader_returnsNull() {
+        A2AVersionProvider p = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p));
+
+        assertNull(resolver.resolve("99.0"));
+    }
+
+    @Test
+    void soleProvider_becomesDefault_evenIfNotMarked() {
+        A2AVersionProvider p = TestProviders.provider("1.0", false, "/a2a_rest_v1.0", "/");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p));
+
+        assertSame(p, resolver.resolve(null));
+    }
+
+    @Test
+    void multipleDefaults_throwsException() {
+        A2AVersionProvider p1 = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionProvider p2 = TestProviders.provider("0.3", true, "/a2a_rest_v0.3", "/v1");
+
+        assertThrows(IllegalStateException.class, () -> new A2AVersionResolver(List.of(p1, p2)));
+    }
+
+    @Test
+    void multipleProviders_noDefault_resolveNull_returnsNull() {
+        A2AVersionProvider p1 = TestProviders.provider("1.0", false, "/a2a_rest_v1.0", "/");
+        A2AVersionProvider p2 = TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p1, p2));
+
+        assertNull(resolver.resolve(null));
+    }
+
+    @Test
+    void hasProviders_empty_returnsFalse() {
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of());
+        assertFalse(resolver.hasProviders());
+    }
+
+    @Test
+    void hasProviders_nonEmpty_returnsTrue() {
+        A2AVersionProvider p = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p));
+        assertTrue(resolver.hasProviders());
+    }
+
+    @Test
+    void supportedVersionsString_returnsCommaSeparatedInInsertionOrder() {
+        A2AVersionProvider p1 = TestProviders.provider("1.0", true, "/a2a_rest_v1.0", "/");
+        A2AVersionProvider p2 = TestProviders.provider("0.3", false, "/a2a_rest_v0.3", "/v1");
+        A2AVersionResolver resolver = new A2AVersionResolver(List.of(p1, p2));
+
+        assertEquals("1.0, 0.3", resolver.supportedVersionsString());
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/AgentCardRoutingFilterTest.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/AgentCardRoutingFilterTest.java
@@ -1,0 +1,95 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class AgentCardRoutingFilterTest {
+
+    @Mock
+    Instance<A2AVersionProvider> allVersionProviders;
+
+    @InjectMocks
+    AgentCardRoutingFilter filter;
+
+    private void setupProviders(A2AVersionProvider... providers) {
+        when(allVersionProviders.iterator()).thenAnswer(inv -> List.of(providers).iterator());
+    }
+
+    @Test
+    void nonGetRequest_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        when(ctx.getMethod()).thenReturn("POST");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).getUriInfo();
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+
+    @Test
+    void pathNotEndingInAgentCard_isSkipped() throws IOException {
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getMethod()).thenReturn("GET");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+
+    @Test
+    void noProviders_doesNotRoute() throws IOException {
+        setupProviders();
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getMethod()).thenReturn("GET");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/.well-known/agent-card.json");
+
+        filter.filter(ctx);
+
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+
+    @Test
+    void multipleProviders_lowerVersionOnly_doesNotRoute() throws IOException {
+        // Verify that the filter initializes without error when providers are present
+        setupProviders(
+                TestProviders.provider("0.3", "/a2a_rest_v0.3", "/v1"),
+                TestProviders.provider("1.0", "/a2a_rest_v1.0", "/"));
+
+        ContainerRequestContext ctx = mock(ContainerRequestContext.class);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(ctx.getMethod()).thenReturn("GET");
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/tasks");
+
+        filter.filter(ctx);
+
+        // Path doesn't match agent-card, so no routing even with providers present
+        verify(ctx, never()).setRequestUri(any(), any());
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/InternalPathsTest.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/InternalPathsTest.java
@@ -1,0 +1,64 @@
+package org.wildfly.a2a.jakarta.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InternalPathsTest {
+
+    @Test
+    void nullValue_returnsEmpty() {
+        assertEquals("", InternalPaths.escapeJsonValue(null));
+    }
+
+    @Test
+    void plainString_isUnchanged() {
+        assertEquals("hello world", InternalPaths.escapeJsonValue("hello world"));
+    }
+
+    @Test
+    void backslash_isEscaped() {
+        assertEquals("\\\\", InternalPaths.escapeJsonValue("\\"));
+    }
+
+    @Test
+    void doubleQuote_isEscaped() {
+        assertEquals("\\\"", InternalPaths.escapeJsonValue("\""));
+    }
+
+    @Test
+    void newline_isEscaped() {
+        assertEquals("\\n", InternalPaths.escapeJsonValue("\n"));
+    }
+
+    @Test
+    void carriageReturn_isEscaped() {
+        assertEquals("\\r", InternalPaths.escapeJsonValue("\r"));
+    }
+
+    @Test
+    void tab_isEscaped() {
+        assertEquals("\\t", InternalPaths.escapeJsonValue("\t"));
+    }
+
+    @Test
+    void controlCharacterNul_isUnicodeEscaped() {
+        assertEquals("\\u0000", InternalPaths.escapeJsonValue(String.valueOf((char) 0)));
+    }
+
+    @Test
+    void controlCharacterSoh_isUnicodeEscaped() {
+        assertEquals("\\u0001", InternalPaths.escapeJsonValue(String.valueOf((char) 1)));
+    }
+
+    @Test
+    void controlCharacterUs_isUnicodeEscaped() {
+        assertEquals("\\u001f", InternalPaths.escapeJsonValue(String.valueOf((char) 31)));
+    }
+
+    @Test
+    void mixedValue_allSpecialsAreEscaped() {
+        String input = "a\"b\\c\nd" + (char) 0 + "e";
+        assertEquals("a\\\"b\\\\c\\nd\\u0000e", InternalPaths.escapeJsonValue(input));
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/RuntimeDelegateExtension.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/RuntimeDelegateExtension.java
@@ -1,0 +1,25 @@
+package org.wildfly.a2a.jakarta.common;
+
+import jakarta.ws.rs.ext.RuntimeDelegate;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RuntimeDelegateExtension implements BeforeAllCallback, AfterAllCallback {
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        RuntimeDelegate rd = mock(RuntimeDelegate.class);
+        when(rd.createResponseBuilder()).thenAnswer(inv -> new SimpleResponseBuilder());
+        RuntimeDelegate.setInstance(rd);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        RuntimeDelegate.setInstance(null);
+    }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/SimpleResponse.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/SimpleResponse.java
@@ -1,0 +1,56 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+
+class SimpleResponse extends Response {
+
+    private final int status;
+    private final Object entity;
+
+    SimpleResponse(int status, Object entity) {
+        this.status = status;
+        this.entity = entity;
+    }
+
+    @Override public int getStatus() { return status; }
+    @Override public StatusType getStatusInfo() { return Status.fromStatusCode(status); }
+    @Override public Object getEntity() { return entity; }
+
+    @Override public <T> T readEntity(Class<T> entityType) { throw new UnsupportedOperationException(); }
+    @Override public <T> T readEntity(GenericType<T> entityType) { throw new UnsupportedOperationException(); }
+    @Override public <T> T readEntity(Class<T> entityType, Annotation[] annotations) { throw new UnsupportedOperationException(); }
+    @Override public <T> T readEntity(GenericType<T> entityType, Annotation[] annotations) { throw new UnsupportedOperationException(); }
+    @Override public boolean hasEntity() { return entity != null; }
+    @Override public boolean bufferEntity() { return false; }
+    @Override public void close() {}
+    @Override public MediaType getMediaType() { return null; }
+    @Override public Locale getLanguage() { return null; }
+    @Override public int getLength() { return -1; }
+    @Override public Set<String> getAllowedMethods() { return Set.of(); }
+    @Override public Map<String, NewCookie> getCookies() { return Map.of(); }
+    @Override public EntityTag getEntityTag() { return null; }
+    @Override public Date getDate() { return null; }
+    @Override public Date getLastModified() { return null; }
+    @Override public URI getLocation() { return null; }
+    @Override public Set<Link> getLinks() { return Set.of(); }
+    @Override public boolean hasLink(String relation) { return false; }
+    @Override public Link getLink(String relation) { return null; }
+    @Override public Link.Builder getLinkBuilder(String relation) { return null; }
+    @Override public MultivaluedMap<String, Object> getMetadata() { return new MultivaluedHashMap<>(); }
+    @Override public MultivaluedMap<String, String> getStringHeaders() { return new MultivaluedHashMap<>(); }
+    @Override public String getHeaderString(String name) { return null; }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/SimpleResponseBuilder.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/SimpleResponseBuilder.java
@@ -1,0 +1,64 @@
+package org.wildfly.a2a.jakarta.common;
+
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import jakarta.ws.rs.core.CacheControl;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Variant;
+
+class SimpleResponseBuilder extends Response.ResponseBuilder {
+
+    private int status;
+    private Object entity;
+
+    @Override
+    public Response build() {
+        return new SimpleResponse(status, entity);
+    }
+
+    @Override
+    public Response.ResponseBuilder clone() {
+        SimpleResponseBuilder copy = new SimpleResponseBuilder();
+        copy.status = this.status;
+        copy.entity = this.entity;
+        return copy;
+    }
+
+    @Override public Response.ResponseBuilder status(int status) { this.status = status; return this; }
+    @Override public Response.ResponseBuilder status(int status, String reasonPhrase) { this.status = status; return this; }
+    @Override public Response.ResponseBuilder entity(Object entity) { this.entity = entity; return this; }
+    @Override public Response.ResponseBuilder entity(Object entity, Annotation[] annotations) { this.entity = entity; return this; }
+    @Override public Response.ResponseBuilder type(MediaType type) { return this; }
+    @Override public Response.ResponseBuilder type(String type) { return this; }
+    @Override public Response.ResponseBuilder allow(String... methods) { return this; }
+    @Override public Response.ResponseBuilder allow(Set<String> methods) { return this; }
+    @Override public Response.ResponseBuilder cacheControl(CacheControl cacheControl) { return this; }
+    @Override public Response.ResponseBuilder encoding(String encoding) { return this; }
+    @Override public Response.ResponseBuilder header(String name, Object value) { return this; }
+    @Override public Response.ResponseBuilder replaceAll(MultivaluedMap<String, Object> headers) { return this; }
+    @Override public Response.ResponseBuilder language(String language) { return this; }
+    @Override public Response.ResponseBuilder language(Locale language) { return this; }
+    @Override public Response.ResponseBuilder variant(Variant variant) { return this; }
+    @Override public Response.ResponseBuilder contentLocation(URI location) { return this; }
+    @Override public Response.ResponseBuilder cookie(NewCookie... cookies) { return this; }
+    @Override public Response.ResponseBuilder expires(Date expires) { return this; }
+    @Override public Response.ResponseBuilder lastModified(Date lastModified) { return this; }
+    @Override public Response.ResponseBuilder location(URI location) { return this; }
+    @Override public Response.ResponseBuilder tag(EntityTag tag) { return this; }
+    @Override public Response.ResponseBuilder tag(String tag) { return this; }
+    @Override public Response.ResponseBuilder variants(Variant... variants) { return this; }
+    @Override public Response.ResponseBuilder variants(List<Variant> variants) { return this; }
+    @Override public Response.ResponseBuilder links(Link... links) { return this; }
+    @Override public Response.ResponseBuilder link(URI uri, String rel) { return this; }
+    @Override public Response.ResponseBuilder link(String uri, String rel) { return this; }
+}

--- a/http-common/src/test/java/org/wildfly/a2a/jakarta/common/TestProviders.java
+++ b/http-common/src/test/java/org/wildfly/a2a/jakarta/common/TestProviders.java
@@ -1,0 +1,24 @@
+package org.wildfly.a2a.jakarta.common;
+
+class TestProviders {
+
+    static A2AVersionProvider provider(String version, boolean isDefault, String internalPrefix, String restBasePath) {
+        return new A2AVersionProvider() {
+            @Override public String getVersion() { return version; }
+            @Override public boolean isDefaultVersion() { return isDefault; }
+            @Override public String getInternalPathPrefix() { return internalPrefix; }
+            @Override public String getRestBasePath() { return restBasePath; }
+        };
+    }
+
+    static A2AVersionProvider provider(String version, String internalPrefix, String restBasePath) {
+        return provider(version, false, internalPrefix, restBasePath);
+    }
+
+    static A2AVersionProvider jsonRpcProvider(String version, boolean isDefault) {
+        return provider(version, isDefault, "/a2a_jsonrpc_v" + version, null);
+    }
+
+    private TestProviders() {
+    }
+}

--- a/impl/jsonrpc/src/main/java/org/wildfly/a2a/jakarta/jsonrpc/A2AServerResource.java
+++ b/impl/jsonrpc/src/main/java/org/wildfly/a2a/jakarta/jsonrpc/A2AServerResource.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.core.SecurityContext;
 
 import org.a2aproject.sdk.transport.jsonrpc.handler.JSONRPCHandler;
 
+// JAX-RS @Path annotations cannot be parameterized, so each protocol version requires a separate resource class.
 @Path("/a2a_jsonrpc_v1.0")
 public class A2AServerResource {
 
@@ -25,6 +26,7 @@ public class A2AServerResource {
 
     private A2AServerResourceDelegate delegate;
 
+    // Per-request JAX-RS resource — no synchronization needed; each request gets a new instance.
     private A2AServerResourceDelegate getDelegate() {
         if (delegate == null) {
             delegate = new A2AServerResourceDelegate(jsonRpcHandler);

--- a/impl/rest/src/main/java/org/wildfly/a2a/jakarta/rest/A2ARestServerResource.java
+++ b/impl/rest/src/main/java/org/wildfly/a2a/jakarta/rest/A2ARestServerResource.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.core.SecurityContext;
 
 import org.a2aproject.sdk.transport.rest.handler.RestHandler;
 
+// JAX-RS @Path annotations cannot be parameterized, so each protocol version requires a separate resource class.
 @Path("/a2a_rest_v1.0")
 public class A2ARestServerResource {
 
@@ -28,6 +29,7 @@ public class A2ARestServerResource {
 
     private A2ARestServerResourceDelegate delegate;
 
+    // Per-request JAX-RS resource — no synchronization needed; each request gets a new instance.
     private A2ARestServerResourceDelegate getDelegate() {
         if (delegate == null) {
             delegate = new A2ARestServerResourceDelegate(restHandler);

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 
         <version.hamcrest>2.2</version.hamcrest>
         <version.junit>5.12.2</version.junit>
+        <version.mockito>5.12.0</version.mockito>
         <version.org.wildfly.arquillian>5.1.0.Beta11</version.org.wildfly.arquillian>
         <version.org.jboss.arquillian>1.10.0.Final</version.org.jboss.arquillian>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
@@ -208,6 +209,12 @@
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
                 <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${version.mockito}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
…nit tests

- Extract InternalPaths with shared path constants and JSON-escape helper
- Fix charset handling and exception chaining in A2AJsonRpcAcceptFilter
- Fix import ordering in A2AJsonRpcAcceptFilter (java.* before jakarta.*)
- Escape all U+0000-U+001F control characters in escapeJsonValue per RFC 8259
- Use LinkedHashMap in A2AVersionResolver for deterministic version ordering
- Add unit tests for all http-common filters and A2AVersionResolver
- Add shared RuntimeDelegateExtension and TestProviders test utilities